### PR TITLE
Added continue to _process_search_query when no data present in the results

### DIFF
--- a/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
+++ b/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
@@ -1194,7 +1194,7 @@ class ArangoVector(VectorStore):
                     result["metadata"],
                 )
 
-                if not result.get("data"):
+                if not data:
                     continue
 
                 _key = data.pop("_key")

--- a/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
+++ b/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
@@ -1193,6 +1193,10 @@ class ArangoVector(VectorStore):
                     result["score"],
                     result["metadata"],
                 )
+
+                if not result.get("data"):
+                    continue
+
                 _key = data.pop("_key")
                 page_content = data.pop(self.text_field)
                 doc = Document(


### PR DESCRIPTION
# Description

This PR addresses an AttributeError that occurs during hybrid searches. Specifically, when using SearchType.HYBRID, the search can occasionally return a result object where the data key is None, such as {'data': None, 'score': 0.01639344262295082, 'metadata': {}}.

The existing code in _process_search_query did not account for this scenario and would attempt to call methods like .pop() on the None value, raising an AttributeError: 'NoneType' object has no attribute 'pop'.

The fix introduces a conditional check at the beginning of the result processing loop. If a result contains None for the data field, it now safely skips to the next iteration using continue, preventing the error and ensuring the search process completes successfully.

## Type of Change
[ ] New feature

[x] Bug fix

[ ] Breaking change

[ ] Project configuration change

## Complexity
Low

## How Has This Been Tested?
[x] Unit tests

[x] Integration tests

[x] Manual tests

## Checklist
[ ] Unit tests updated

[ ] Integration tests updated

[ ] CHANGELOG.md updated