### PR TITLE
fix: add missing `vector_index_name`

### DIFF
--- a/libs/arangodb/doc/vectorstores.rst
+++ b/libs/arangodb/doc/vectorstores.rst
@@ -415,7 +415,7 @@ Custom Collection Setup
         embedding_dimension=1536,
         database=db,
         collection_name="custom_vectors",
-        index_name="my_vector_index",
+        vector_index_name="my_vector_index",
         num_centroids=10,     # More centroids for larger datasets
         search_type=SearchType.VECTOR,  # or SearchType.HYBRID
     )

--- a/libs/arangodb/langchain_arangodb/chains/graph_qa/arangodb.py
+++ b/libs/arangodb/langchain_arangodb/chains/graph_qa/arangodb.py
@@ -604,11 +604,13 @@ class ArangoGraphQAChain(Chain):
             callbacks=callbacks,
         )
 
+        content = str(result.content if isinstance(result, AIMessage) else result)
+
         # Add summary
         text = "Summary:"
         _run_manager.on_text(text, end="\n", verbose=self.verbose)
         _run_manager.on_text(
-            str(result.content) if isinstance(result, AIMessage) else result,
+            content,
             color="green",
             end="\n",
             verbose=self.verbose,
@@ -632,7 +634,7 @@ class ArangoGraphQAChain(Chain):
         if self.chat_history_store:
             self.chat_history_store.add_user_message(user_input)
             self.chat_history_store.add_ai_message(aql_query)
-            self.chat_history_store.add_ai_message(result)
+            self.chat_history_store.add_ai_message(content)
 
         return results
 

--- a/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
+++ b/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
@@ -886,7 +886,7 @@ class ArangoVector(VectorStore):
         search_type: SearchType = DEFAULT_SEARCH_TYPE,
         embedding_field: str = "embedding",
         text_field: str = "text",
-        index_name: str = "vector_index",
+        vector_index_name: str = "vector_index",
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
         num_centroids: int = 1,
         ids: Optional[List[str]] = None,
@@ -924,8 +924,8 @@ class ArangoVector(VectorStore):
         :type embedding_field: str
         :param text_field: The field name to store text content. Defaults to "text".
         :type text_field: str
-        :param index_name: The name of the vector index. Defaults to "vector_index".
-        :type index_name: str
+        :param vector_index_name: The name of the vector index. Defaults to "vector_index".
+        :type vector_index_name: str
         :param distance_strategy: The distance metric to use. Can be
             DistanceStrategy.COSINE or DistanceStrategy.EUCLIDEAN_DISTANCE.
             Defaults to DistanceStrategy.COSINE.
@@ -1005,7 +1005,7 @@ class ArangoVector(VectorStore):
             search_type=search_type,
             embedding_field=embedding_field,
             text_field=text_field,
-            vector_index_name=index_name,
+            vector_index_name=vector_index_name,
             distance_strategy=distance_strategy,
             num_centroids=num_centroids,
             keyword_index_name=keyword_index_name,
@@ -1036,6 +1036,7 @@ class ArangoVector(VectorStore):
         database: StandardDatabase,
         embedding_field: str = "embedding",
         text_field: str = "text",
+        vector_index_name: str = "vector_index",
         batch_size: int = 1000,
         aql_return_text_query: str = "",
         insert_text: bool = False,
@@ -1066,7 +1067,10 @@ class ArangoVector(VectorStore):
             Defaults to "embedding".
         :type embedding_field: str
         :param text_field: The field name to store text content. Defaults to "text".
+            Only used if `insert_text` is True.
         :type text_field: str
+        :param vector_index_name: The name of the vector index. Defaults to "vector_index".
+        :type vector_index_name: str
         :param batch_size: Number of documents to process in each batch.
             Defaults to 1000.
         :type batch_size: int
@@ -1161,6 +1165,7 @@ class ArangoVector(VectorStore):
                 collection_name=collection_name,
                 embedding_field=embedding_field,
                 text_field=text_field,
+                vector_index_name=vector_index_name,
                 ids=ids,
                 insert_text=insert_text,
                 search_type=search_type,

--- a/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
+++ b/libs/arangodb/langchain_arangodb/vectorstores/arangodb_vector.py
@@ -924,7 +924,8 @@ class ArangoVector(VectorStore):
         :type embedding_field: str
         :param text_field: The field name to store text content. Defaults to "text".
         :type text_field: str
-        :param vector_index_name: The name of the vector index. Defaults to "vector_index".
+        :param vector_index_name: The name of the vector index.
+            Defaults to "vector_index".
         :type vector_index_name: str
         :param distance_strategy: The distance metric to use. Can be
             DistanceStrategy.COSINE or DistanceStrategy.EUCLIDEAN_DISTANCE.
@@ -1069,7 +1070,8 @@ class ArangoVector(VectorStore):
         :param text_field: The field name to store text content. Defaults to "text".
             Only used if `insert_text` is True.
         :type text_field: str
-        :param vector_index_name: The name of the vector index. Defaults to "vector_index".
+        :param vector_index_name: The name of the vector index.
+            Defaults to "vector_index".
         :type vector_index_name: str
         :param batch_size: Number of documents to process in each batch.
             Defaults to 1000.

--- a/libs/arangodb/tests/integration_tests/vectorstores/test_arangodb_vector.py
+++ b/libs/arangodb/tests/integration_tests/vectorstores/test_arangodb_vector.py
@@ -394,9 +394,8 @@ def test_arangovector_delete_documents(
     assert remaining_docs_check_raw is not None, (
         "collection.get_many() returned None for remaining_docs_check"
     )
-    assert isinstance(remaining_docs_check_raw, list), (
-        f"collection.get_many() expected list for remaining_docs_check,\
-              got {type(remaining_docs_check_raw)}"
+    m = f"collection.get_many() expected list for remaining_docs_check, got {type(remaining_docs_check_raw)}"  # noqa: E501
+    assert isinstance(remaining_docs_check_raw, list), m
     remaining_docs_check: List[Dict[str, Any]] = remaining_docs_check_raw
     assert len(remaining_docs_check) == 2
 

--- a/libs/arangodb/tests/integration_tests/vectorstores/test_arangodb_vector.py
+++ b/libs/arangodb/tests/integration_tests/vectorstores/test_arangodb_vector.py
@@ -383,9 +383,8 @@ def test_arangovector_delete_documents(
     assert deleted_docs_check_raw is not None, (
         "collection.get_many() returned None for deleted_docs_check"
     )
-    assert isinstance(deleted_docs_check_raw, list), (
-        f"collection.get_many() expected list for deleted_docs_check,\
-              got {type(deleted_docs_check_raw)}"
+    m = f"collection.get_many() expected list for deleted_docs_check, got {type(deleted_docs_check_raw)}"  # noqa: E501
+    assert isinstance(deleted_docs_check_raw, list), m
     deleted_docs_check: List[Dict[str, Any]] = deleted_docs_check_raw
     assert len(deleted_docs_check) == 0
 
@@ -408,7 +407,6 @@ def test_arangovector_delete_documents(
     assert retrieved_contents == sorted(
         [texts_to_embed[0], texts_to_embed[2]]
     )  # doc_to_keep1, doc_to_keep2
-
 
 
 @pytest.mark.usefixtures("clear_arangodb_database")

--- a/libs/arangodb/tests/integration_tests/vectorstores/test_arangodb_vector.py
+++ b/libs/arangodb/tests/integration_tests/vectorstores/test_arangodb_vector.py
@@ -50,7 +50,7 @@ def test_arangovector_from_texts_and_similarity_search(
         metadatas=metadatas,
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         overwrite_index=True,  # Ensure clean state for the index
     )
 
@@ -107,7 +107,7 @@ def test_arangovector_euclidean_distance(
         embedding=fake_embedding_function,
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
         overwrite_index=True,
     )
@@ -160,7 +160,7 @@ def test_arangovector_similarity_search_with_score(
         metadatas=metadatas,
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         overwrite_index=True,
     )
 
@@ -194,7 +194,7 @@ def test_arangovector_similarity_search_with_score(
         database=db,  # db is managed by fixture, collection will be overwritten
         collection_name="test_collection"
         + "_l2",  # Use a different collection or ensure overwrite
-        index_name="test_index" + "_l2",
+        vector_index_name="test_index" + "_l2",
         distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
         overwrite_index=True,
     )
@@ -284,7 +284,7 @@ def test_arangovector_retriever_search_threshold(
         metadatas=metadatas,
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         overwrite_index=True,
     )
 
@@ -357,7 +357,7 @@ def test_arangovector_delete_documents(
         ids=doc_ids,  # Pass our custom IDs
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         overwrite_index=True,
     )
 
@@ -386,7 +386,6 @@ def test_arangovector_delete_documents(
     assert isinstance(deleted_docs_check_raw, list), (
         f"collection.get_many() expected list for deleted_docs_check,\
               got {type(deleted_docs_check_raw)}"
-    )
     deleted_docs_check: List[Dict[str, Any]] = deleted_docs_check_raw
     assert len(deleted_docs_check) == 0
 
@@ -399,7 +398,6 @@ def test_arangovector_delete_documents(
     assert isinstance(remaining_docs_check_raw, list), (
         f"collection.get_many() expected list for remaining_docs_check,\
               got {type(remaining_docs_check_raw)}"
-    )
     remaining_docs_check: List[Dict[str, Any]] = remaining_docs_check_raw
     assert len(remaining_docs_check) == 2
 
@@ -412,7 +410,7 @@ def test_arangovector_delete_documents(
     )  # doc_to_keep1, doc_to_keep2
 
 
-# NEW TEST
+
 @pytest.mark.usefixtures("clear_arangodb_database")
 def test_arangovector_similarity_search_with_return_fields(
     arangodb_credentials: ArangoCredentials,
@@ -439,7 +437,7 @@ def test_arangovector_similarity_search_with_return_fields(
         ids=doc_ids,
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         overwrite_index=True,
     )
 
@@ -519,7 +517,7 @@ def test_arangovector_max_marginal_relevance_search(
         ids=doc_ids,
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         overwrite_index=True,
     )
 
@@ -574,7 +572,7 @@ def test_arangovector_delete_vector_index(
         embedding=fake_embedding_function,
         database=db,
         collection_name="test_collection",
-        index_name="test_index",
+        vector_index_name="test_index",
         overwrite_index=False,
     )
 
@@ -980,7 +978,7 @@ def test_arangovector_from_existing_collection(
         database=db,
         embedding_field="custom_embedding",
         text_field="custom_text",
-        index_name="custom_vector_index",
+        vector_index_name="custom_vector_index",
         aql_return_text_query=custom_aql_query,
         insert_text=True,
     )
@@ -1011,7 +1009,7 @@ def test_arangovector_from_existing_collection(
         database=db,
         embedding_field="embedding",
         text_field="combined_text",
-        index_name="skip_vector_index",  # Use a different index name
+        vector_index_name="skip_vector_index",  # Use a different index name
         skip_existing_embeddings=True,
         insert_text=True,  # Important for search to work
     )
@@ -1027,7 +1025,7 @@ def test_arangovector_from_existing_collection(
         database=db,
         embedding_field="content_embedding",
         text_field="combined_title_content",
-        index_name="content_vector_index",  # Use a different index name
+        vector_index_name="content_vector_index",  # Use a different index name
         insert_text=True,  # Already set to True, but kept for clarity
     )
 


### PR DESCRIPTION
- Adds a missing `vector_index_name` parameter to an `ArangoVector` method
- Minor cleanup for typing & linting purposes