### PR TITLE
bump: 3.12 to 3.13 for Github Actions

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python-version:
           - "3.9"
-          - "3.12"
+          - "3.13"
     name: "poetry run pytest -m compile tests/integration_tests #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -30,7 +30,7 @@ jobs:
         # so linting on fewer versions makes CI faster.
         python-version:
           - "3.9"
-          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python-version:
           - "3.9"
-          - "3.12"
+          - "3.13"
     name: "make test #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updating the upper bound of our Github Actions to use Python 3.13 instead of 3.12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and testing infrastructure to use Python 3.13 for all validation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->